### PR TITLE
refac(various): server ip determined by OS

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import { Template } from '../../components';
 import { connect } from 'react-redux';
+import { SERVER_IP } from '../../private';
 import './orderForm.css';
 
-const ADD_ORDER_URL = "http://localhost:4000/api/add-order"
+const ADD_ORDER_URL = `${SERVER_IP}/api/add-order`
 
 const mapStateToProps = (state) => ({
     auth: state.auth,

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Template } from '../../components';
+import { SERVER_IP } from '../../private';
 import './viewOrders.css';
 
 class ViewOrders extends Component {
@@ -8,7 +9,7 @@ class ViewOrders extends Component {
     }
 
     componentDidMount() {
-        fetch('http://localhost:4000/api/current-orders')
+        fetch(`${SERVER_IP}/api/current-orders`)
             .then(response => response.json())
             .then(response => {
                 if(response.success) {

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,0 +1,3 @@
+const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';

--- a/application/src/redux/actions/authActions.js
+++ b/application/src/redux/actions/authActions.js
@@ -1,4 +1,5 @@
 import { LOGIN, LOGOUT } from './types';
+import { SERVER_IP } from '../../private'
 
 const finishLogin = (email, token) => {
     return {
@@ -12,7 +13,7 @@ const finishLogin = (email, token) => {
 
 export const loginUser = (email, password) => {
     return (dispatch) => {
-        fetch('http://localhost:4000/api/login', {
+        fetch(`${SERVER_IP}/api/login`, {
             method: 'POST',
             body: JSON.stringify({
                 email,


### PR DESCRIPTION
This PR refactors out the server location to a `private.js` file that checks your OS and assigns either `localhost` or the windows default docker IP, 192.168.99.100. There is a rare chance that the docker-machine assigns an IP other than the  default, but it's rare enough that I'm comfortable letting this rock for now.

The `private.js` file is not .gitignore'd because there's no keys and this similar type of refactor is seen on many projects.

I just tested this on my Windows laptop and it works.