### PR TITLE
Fix: Order form submit bug

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
Inside orderForm.js, within menuItemChosen(event), "item" is not a state variable inside this.state. Changed it to "order_item" to fix the problem.