### PR TITLE
Route guarding

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -46,6 +46,10 @@ class OrderForm extends Component {
         .catch(error => console.error(error));
     }
 
+    componentDidMount() {
+        this.props.auth.token == null && this.props.history.push('/login');
+    }
+
     render() {
         return (
             <Template>

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,7 +1,12 @@
 import React, { Component } from 'react';
 import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
+import { connect } from 'react-redux';
 import './viewOrders.css';
+
+const mapStateToDispatch = state => ({
+    auth: state.auth
+})
 
 class ViewOrders extends Component {
     state = {
@@ -9,6 +14,10 @@ class ViewOrders extends Component {
     }
 
     componentDidMount() {
+        if (this.props.auth.token == null) {
+            this.props.history.push('/login');
+            return;
+        }
         fetch(`${SERVER_IP}/api/current-orders`)
             .then(response => response.json())
             .then(response => {
@@ -49,4 +58,4 @@ class ViewOrders extends Component {
     }
 }
 
-export default ViewOrders;
+export default connect(mapStateToDispatch, null)(ViewOrders);

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,3 @@
 const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
 
-export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://127.0.0.1:4000';


### PR DESCRIPTION
The /order and /view-order pages now redirect back to the /login page if the redux auth.token is null.

Side note: I got one of those "can't perform React state update on unmounted component" which I was able to get rid of by adding a "return" between the this.props.history.push("/login") and the fetch(...) method to prevent the fetch GET call from calling this.setState(...),